### PR TITLE
Allow window filter to match owner or window name

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[report]
+exclude_lines =
+    coverage: disable
+    def __repr__
+    raise AssertionError
+    raise NotImplementedError
+    if __name__ == .__main__.:

--- a/lswin/__init__.py
+++ b/lswin/__init__.py
@@ -3,21 +3,22 @@
 import sys
 from argparse import ArgumentParser
 from fnmatch import fnmatch
+from typing import Iterable
 
 from ._macos_window import Window
 
-__version__ = '0.1'
+__version__ = '0.2'
 
 
-def get_windows(name_filter: str = None, include_off_screen: bool = False):
+def get_windows(name_filter: str = '', include_off_screen: bool = False) -> Iterable[Window]:
     '''Return all windows optionally filtered by name or on-screen state'''
+    name_filter = name_filter.lower()
     def included(window: Window) -> bool:
         if include_off_screen or window.is_on_screen:
             if name_filter:
-                name = f'{window.owner_name or ""} {window.name or ""}'.lower()
-                return fnmatch(name, name_filter.lower())
-            if window.name:
-                return len(window.name.strip()) > 0
+                return any(fnmatch((name or '').lower(), name_filter)
+                           for name in (window.owner_name, window.name))
+            return bool(window.owner_name.strip() or window.name.strip())
         return False
 
     windows = tuple(w for w in Window.all() if included(w))
@@ -25,23 +26,31 @@ def get_windows(name_filter: str = None, include_off_screen: bool = False):
     return Window.sort(windows)
 
 
-def main():
-    '''The main command-line entry point'''
-    parser = ArgumentParser()
-    parser.add_argument('--filter', '-f', default=None)
-    parser.add_argument('--all', '-a', action='store_true')
-    arguments = parser.parse_args()
-
-    windows = get_windows(arguments.filter, arguments.all)
+def print_window_table(windows: Iterable[Window], out_file=sys.stdout):
+    '''Print a fixed-width table of window objects'''
     if windows:
         message = '{0:>6}  {1:>6}  {2:43}  {3:>5}  {4:>5}'
-        print(message.format('PID', 'WID', 'Process: Window', 'X', 'Y'))
-        print('-'*6, '-'*6, '-'*43, '-'*5, '-'*5, sep='  ')
+        print(message.format('PID', 'WID', 'Process: Window', 'X', 'Y'), file=out_file)
+        print('-'*6, '-'*6, '-'*43, '-'*5, '-'*5, sep='  ', file=out_file)
         for window in windows:
             name = str(window)
             if len(name) > 43:
                 name = name[:40] + '...'
-            print(message.format(window.owner_pid, window.number, name, window.x, window.y))
+            print(message.format(window.owner_pid, window.number, name, window.x, window.y), file=out_file)
+
+
+def main():
+    '''The main command-line entry point'''
+    parser = ArgumentParser(description=__doc__.partition('\n')[0])
+    parser.add_argument('--version', '-v', action='version', version=f'%(prog)s {__version__}')
+    parser.add_argument('--filter', '-f', default='',
+                        help='filter window names using a case-insensitive POSIX glob-style pattern (e.g. "*term*")')
+    parser.add_argument('--all', '-a', action='store_true',
+                        help='include both on- and off-screen windows')
+    arguments = parser.parse_args()
+
+    windows = get_windows(arguments.filter, arguments.all)
+    print_window_table(windows)
 
 
 if __name__ == '__main__':

--- a/lswin/_macos_window.py
+++ b/lswin/_macos_window.py
@@ -39,6 +39,6 @@ class Window:
             yield cls(window)
 
     @classmethod
-    def sort(cls, windows: Iterable[Window]):
+    def sort(cls, windows: Iterable[Window]) -> Iterable[Window]:
         '''Return windows sorted by `owner_pid`, `number` ascending'''
         return sorted(windows, key=lambda w: (w.owner_pid, w.number))

--- a/tests/macos_window_test.py
+++ b/tests/macos_window_test.py
@@ -1,0 +1,51 @@
+# pylint: disable=missing-docstring,no-self-use
+from lswin._macos_window import Window
+
+
+class TestMacosWindow:
+    def test_window_attributes(self):
+        macos_api_window = {
+            'kCGWindowIsOnscreen': True,
+            'kCGWindowNumber': 1,
+            'kCGWindowName': 'window_name',
+            'kCGWindowOwnerPID': 2,
+            'kCGWindowOwnerName': 'owner_name',
+            'kCGWindowBounds': {
+                'X': 3,
+                'Y': 4,
+                'Width': 5,
+                'Height': 6
+            },
+            'kCGWindowMemoryUsage': 7,
+        }
+        window = Window(macos_api_window)
+        assert window.is_on_screen
+        assert window.number == 1
+        assert window.name == 'window_name'
+        assert window.owner_pid == 2
+        assert window.owner_name == 'owner_name'
+        assert window.x == 3
+        assert window.y == 4
+        assert window.width == 5
+        assert window.height == 6
+        assert window.memory_bytes == 7
+
+    def test_window_default_attributes(self):
+        macos_api_window = {
+            'kCGWindowNumber': 1,
+            'kCGWindowName': 'window_name',
+            'kCGWindowOwnerPID': 2,
+            'kCGWindowOwnerName': 'owner_name',
+            'kCGWindowMemoryUsage': 7,
+        }
+        window = Window(macos_api_window)
+        assert not window.is_on_screen
+        assert window.number == 1
+        assert window.name == 'window_name'
+        assert window.owner_pid == 2
+        assert window.owner_name == 'owner_name'
+        assert window.x == 0
+        assert window.y == 0
+        assert window.width == 0
+        assert window.height == 0
+        assert window.memory_bytes == 7

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,30 +1,38 @@
-# pylint: disable=missing-docstring
-from unittest.mock import Mock, patch
+# pylint: disable=missing-docstring,no-self-use
+import argparse
+import sys
+from unittest.mock import MagicMock, Mock, patch
+import pytest
 
-from lswin import get_windows
+import lswin
 from lswin._macos_window import Window
 
 
 def _get_mock_window(name: str, on_screen: bool) -> Mock:
-    window = Mock(autospec=Window)
+    window = MagicMock(autospec=Window)
+    window.owner_pid = 1
+    window.number = 11
+    window.x = 10
+    window.y = 20
     window.owner_name = f'owner_{name}'
     window.name = name
     window.is_on_screen = on_screen
+    window.__str__ = lambda self: f'{self.owner_name} {self.name}'
     return window
 
 
 class TestMain:
     def test_get_windows_any_name_on_screen(self):
-        window_one = _get_mock_window('one', True)
-        window_two = _get_mock_window('two', True)
-        window_three = _get_mock_window('three', False)
+        window_one = _get_mock_window('one', on_screen=True)
+        window_two = _get_mock_window('two', on_screen=True)
+        window_three = _get_mock_window('three', on_screen=False)
         all_windows = iter([window_one, window_two, window_three])
         on_screen_windows = iter([window_one, window_two])
         off_screen_windows = iter([window_three])
 
         with patch.object(Window, 'all', return_value=all_windows) as mock_all_windows,\
                 patch.object(Window, 'sort', side_effect=lambda windows: windows) as mock_sort:
-            windows = get_windows()
+            windows = lswin.get_windows()
             mock_all_windows.assert_called_once()
             mock_sort.assert_called_once()
 
@@ -32,16 +40,54 @@ class TestMain:
             assert not any(w in windows for w in off_screen_windows)
 
     def test_get_windows_one_name_on_screen(self):
-        window_one = _get_mock_window('one', True)
-        window_two = _get_mock_window('two', True)
-        window_three = _get_mock_window('three', False)
+        window_one = _get_mock_window('one', on_screen=True)
+        window_two = _get_mock_window('two', on_screen=True)
+        window_three = _get_mock_window('three', on_screen=False)
         all_windows = iter([window_one, window_two, window_three])
 
         with patch.object(Window, 'all', return_value=all_windows) as mock_all_windows,\
                 patch.object(Window, 'sort', side_effect=lambda windows: windows) as mock_sort:
-            windows = get_windows(f'*{window_one.name}*')
+            windows = lswin.get_windows(f'*{window_one.name}*')
             mock_all_windows.assert_called_once()
             mock_sort.assert_called_once()
 
             assert window_one in windows
             assert not any(w in windows for w in (window_two, window_three))
+
+    def test_main_get_windows_arguments(self):
+        mock_arguments = Mock()
+        mock_arguments.filter = Mock()
+        mock_arguments.all = Mock()
+        mock_windows = Mock()
+        with patch.object(argparse.ArgumentParser, 'parse_args', return_value=mock_arguments) as mock_parse_args,\
+                patch.object(lswin, 'get_windows', return_value=mock_windows) as mock_get_windows,\
+                patch.object(lswin, 'print_window_table') as mock_print_window_table:
+            lswin.main()
+
+            # Verify get_windows() executes with --filter and --all CLI argument values
+            mock_parse_args.assert_called_once()
+            mock_get_windows.assert_called_once_with(mock_arguments.filter, mock_arguments.all)
+
+            # Verify print_windows() executes with the result of get_windows()
+            mock_print_window_table.assert_called_once_with(mock_windows)
+
+    @pytest.mark.parametrize(
+        ('out_file',),
+        [(sys.stdout,), (sys.stderr,)],
+        ids=['stdout', 'stderr'])
+    def test_main_print_window_table_arguments(self, out_file):
+        window_one = _get_mock_window('one', on_screen=True)
+        window_two = _get_mock_window('two', on_screen=True)
+        with patch('builtins.print') as mock_print:
+            lswin.print_window_table((window_one, window_two), out_file=out_file)
+
+            # Verify print() executes at least with expected window names
+            mock_print.assert_called()
+            expected_window_names = [str(window_one), str(window_two),]
+            for output in mock_print.call_args_list:
+                if not expected_window_names:
+                    break
+                if expected_window_names[0] in ''.join(output[0]):
+                    expected_window_names.pop(0)
+                    assert output[-1]['file'] == out_file
+            assert not expected_window_names, f'{len(expected_window_names)} windows were not found'


### PR DESCRIPTION
Allow window filter to match owner or window name

Extend test coverage for `lswin` and macOS `Window` wrapper